### PR TITLE
Add support for older versions of DataFrames

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,3 @@
 julia 0.6
-DataFrames 0.11.3
+DataFrames 0.10
+Missings 0.2

--- a/src/KeyedFrames.jl
+++ b/src/KeyedFrames.jl
@@ -71,6 +71,20 @@ Base.isequal(a::AbstractDataFrame, b::KeyedFrame) = false
 
 Base.hash(kf::KeyedFrame, h::UInt) = hash(kf.key, hash(kf.frame, h))
 
+if Pkg.installed("DataFrames") < v"0.11.3"
+    # Prevent fallback to DataFrames.hash(df::AbstractDataFrame)
+    Base.hash(kf::KeyedFrame) = hash(kf, zero(UInt))
+
+    function Base.hash(df::AbstractDataFrame, h::UInt)
+        h += UInt == UInt32 ? 0xfd8bb02e : 0x6215bada8c8c46de
+        h += hash(size(df))
+        for i in 1:size(df, 2)
+            h = hash(df[i], h)
+        end
+        return h
+    end
+end
+
 ##### SIZE #####
 
 nrow(kf::KeyedFrame) = nrow(kf.frame)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,7 @@
 using KeyedFrames
 using DataFrames
 using Base.Test
+using Missings
 
 @testset "KeyedFrames" begin
     df1 = DataFrame(; a=1:10, b=2:11, c=3:12)


### PR DESCRIPTION
Some `join` tests fail when using DataFrames v0.10, because columns are returned in a different order, but everything works as it should.