### PR TITLE
WiP: Rename permute! to permutecols!

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
 julia 0.6
-DataFrames 0.11.6
+DataFrames 0.11.7	# a701acd required for permutecols!

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -173,6 +173,46 @@ julia> sort(kf2)
 │ 3   │ 2 │ 5 │ 2 │
 ```
 
+## Reordering Columns
+
+Columns may be reordered in-place with `permutecols!`.
+
+```julia
+julia> kf = KeyedFrame(DataFrame(; a=1:5, b=2:6, c=3:7), [:b, :a])
+5×3 KeyedFrames.KeyedFrame
+│ Row │ a │ b │ c │
+├─────┼───┼───┼───┤
+│ 1   │ 1 │ 2 │ 3 │
+│ 2   │ 2 │ 3 │ 4 │
+│ 3   │ 3 │ 4 │ 5 │
+│ 4   │ 4 │ 5 │ 6 │
+│ 5   │ 5 │ 6 │ 7 │
+
+julia> permutecols!(kf, [2, 1, 3]);
+
+julia> df
+5×3 KeyedFrames.KeyedFrame
+│ Row │ b │ a │ c │
+├─────┼───┼───┼───┤
+│ 1   │ 2 │ 1 │ 3 │
+│ 2   │ 3 │ 2 │ 4 │
+│ 3   │ 4 │ 3 │ 5 │
+│ 4   │ 5 │ 4 │ 6 │
+│ 5   │ 6 │ 5 │ 7 │
+
+julia> permutecols!(kf, [:c, :a, :b]);
+
+julia> df
+5×3 KeyedFrames.KeyedFrame
+│ Row │ c │ a │ b │
+├─────┼───┼───┼───┤
+│ 1   │ 3 │ 1 │ 2 │
+│ 2   │ 4 │ 2 │ 3 │
+│ 3   │ 5 │ 3 │ 4 │
+│ 4   │ 6 │ 4 │ 5 │
+│ 5   │ 7 │ 5 │ 6 │
+```
+
 ## Equality
 
 Two `KeyedFrame`s are considered equal to (`==`) each other if their data are equal and they

--- a/src/KeyedFrames.jl
+++ b/src/KeyedFrames.jl
@@ -220,7 +220,6 @@ permutecols!(kf::KeyedFrame, p::AbstractVector) = permutecols!(kf.frame, p)
 
 @deprecate permute!(df::AbstractDataFrame, p::AbstractVector) permutecols!(df, p)
 
-# TODO remove permute! after a suitable period
-export KeyedFrame, permute!
+export KeyedFrame
 
 end

--- a/src/KeyedFrames.jl
+++ b/src/KeyedFrames.jl
@@ -220,6 +220,7 @@ permutecols!(kf::KeyedFrame, p::AbstractVector) = permutecols!(kf.frame, p)
 
 @deprecate permute!(df::AbstractDataFrame, p::AbstractVector) permutecols!(df, p)
 
-export KeyedFrame
+# TODO remove permute! after a suitable period
+export KeyedFrame, permute!
 
 end

--- a/src/KeyedFrames.jl
+++ b/src/KeyedFrames.jl
@@ -3,13 +3,13 @@ module KeyedFrames
 
 using DataFrames
 import DataFrames: SubDataFrame, nrow, ncol, index, deleterows!, delete!, unique!,
-       nonunique, head, tail
+       nonunique, head, tail, permutecols!
 
 struct KeyedFrame <: AbstractDataFrame
     frame::DataFrame
     key::Vector{Symbol}
 
-    function KeyedFrame(df::DataFrame, key::Vector{<:Symbol})
+    function KeyedFrame(df::DataFrame, key::Vector{Symbol})
         key = unique(key)
 
         if !issubset(key, names(df))
@@ -216,15 +216,9 @@ tail(kf::KeyedFrame, r::Int) = KeyedFrame(tail(kf.frame, r), kf.key)
 
 ##### PERMUTE #####
 
-function Base.permute!(df::DataFrame, index::AbstractVector)
-    permute!(DataFrames.columns(df), index)
-    df.colindex = DataFrames.Index(
-        Dict(names(df)[j] => i for (i, j) in enumerate(index)),
-        [names(df)[j] for j in index]
-    )
-end
+permutecols!(kf::KeyedFrame, p::AbstractVector) = permutecols!(kf.frame, p)
 
-Base.permute!(kf::KeyedFrame, index::AbstractVector) = permute!(kf.frame, index)
+@deprecate permute!(df::AbstractDataFrame, p::AbstractVector) permutecols!(df, p)
 
 export KeyedFrame
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -363,15 +363,26 @@ using Base.Test
         @test isequal(join(kf2, kf3; on=[:a => :a, :d => :e], kind=:outer), expected)
     end
 
-    @testset "permute!" begin
+    @testset "permutecols!" begin
         cp = deepcopy(kf1)
 
-        permute!(cp, [1, 3, 2])
+        permutecols!(cp, [1, 3, 2])
         @test isequal(cp, KeyedFrame(DataFrame(; a=1:10, c=3:12, b=2:11), [:a, :b]))
-        permute!(cp, [2, 3, 1])
+        permutecols!(cp, [2, 3, 1])
         @test isequal(cp, KeyedFrame(DataFrame(; c=3:12, b=2:11, a=1:10), [:a, :b]))
 
-        @test_throws Exception permute!(cp, [1, 3])
-        @test_throws Exception permute!(cp, [1, 2, 3, 4])
+        cp = deepcopy(kf1)
+
+        permutecols!(cp, [:a, :c, :b])
+        @test isequal(cp, KeyedFrame(DataFrame(; a=1:10, c=3:12, b=2:11), [:a, :b]))
+        permutecols!(cp, [:c, :b, :a])
+        @test isequal(cp, KeyedFrame(DataFrame(; c=3:12, b=2:11, a=1:10), [:a, :b]))
+
+        @test_throws Exception permutecols!(cp, [1, 2])
+        @test_throws Exception permutecols!(cp, [1, 3])
+        @test_throws Exception permutecols!(cp, [1, 2, 3, 4])
+        @test_throws Exception permutecols!(cp, [:a, :b])
+        @test_throws Exception permutecols!(cp, [:a, :c])
+        @test_throws Exception permutecols!(cp, [:a, :b, :c, :d])
     end
 end


### PR DESCRIPTION
It looks like `permute!(::DataFrame, p)` may be integrated into DataFrames.jl, albeit renamed `permutecols!`. If so, `permute!(::DataFrame, p)` ought to be removed from KeyedFrames.jl and `permute!(::KeyedFrame, p)` renamed `permutecols!`.

Requires https://github.com/JuliaData/DataFrames.jl/pull/1395, which is expected to be part of DataFrames v0.11.7 when it is tagged.