### PR TITLE
Support `getindex(::KeyedFrame, ::typeof(!), ::String)`

### DIFF
--- a/src/KeyedFrames.jl
+++ b/src/KeyedFrames.jl
@@ -116,10 +116,8 @@ Base.getindex(kf::KeyedFrame, ::Colon, ::Colon) = copy(kf)
 # Returns a KeyedFrame
 Base.getindex(kf::KeyedFrame, ::typeof(!), col::AbstractVector) = _kf_getindex(kf, !, col)
 
-# Returns a column
-Base.getindex(kf::KeyedFrame, ::typeof(!), col::ColumnIndex) = frame(kf)[!, col]
-
 # Returns a KeyedFrame or a column (depending on the type of col)
+Base.getindex(kf::KeyedFrame, ::typeof(!), col) = frame(kf)[!, col]
 Base.getindex(kf::KeyedFrame, ::Colon, col) = frame(kf)[:, col]
 
 # Returns a scalar

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -125,6 +125,9 @@ using Test
 
         @test isequal(kf1[:, :b], collect(2:11))
         @test isequal(kf1[:, 2], collect(2:11))
+
+        @test kf1[!, "a"] == 1:10
+        @test isequal(kf1[!, ["a", "b"]], KeyedFrame(DataFrame(; a=1:10, b=2:11), [:a, :b]))
     end
 
     @testset "setindex!" begin


### PR DESCRIPTION
Fixes this problem:
```
MethodError: no method matching getindex(::KeyedFrame, ::typeof(!), ::String)
  Closest candidates are:
    getindex(::KeyedFrame, ::typeof(!), !Matched::AbstractArray{T,1} where T) at /Users/omus/.julia/packages/KeyedFrames/szwPE/src/KeyedFrames.jl:117
    getindex(::KeyedFrame, ::typeof(!), !Matched::Union{Real, Symbol}) at /Users/omus/.julia/packages/KeyedFrames/szwPE/src/KeyedFrames.jl:120
    getindex(::KeyedFrame, !Matched::Colon, ::Any) at /Users/omus/.julia/packages/KeyedFrames/szwPE/src/KeyedFrames.jl:123
    ...
```